### PR TITLE
読み込み終了時に起動する関数の書き方修正

### DIFF
--- a/static/training.html
+++ b/static/training.html
@@ -59,6 +59,6 @@
             document.getElementById("goal").innerHTML = "目標回数：" + param["number"];
             GOAL = parseInt(param["number"]);
         }
-        window.onload = get();
+        window.onload = get;
     </script>
 </html>


### PR DESCRIPTION
window.onload = get() だと、get関数の返り値 undefined を window.onload に代入しちゃうことになるよ